### PR TITLE
Fix typecasting of bytearray to str

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -626,7 +626,7 @@ def _getImports_macholib(pth):
             #    '../lib\x00\x00')
             cmd_type = command[0].cmd
             if cmd_type == LC_RPATH:
-                rpath = str(command[2])
+                rpath = command[2].decode("utf-8")
                 # Remove trailing '\x00' characters.
                 # e.g. '../lib\x00\x00'
                 rpath = rpath.rstrip('\x00')


### PR DESCRIPTION
Changed str() to .decode('utf-8'). str() not converting bytearray to str on OS X/Python 3.4
